### PR TITLE
Rename project to `appsignal-run`

### DIFF
--- a/.changesets/rename-to--appsignal-run-.md
+++ b/.changesets/rename-to--appsignal-run-.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: change
+---
+
+Rename the project to `appsignal-run`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# `appsignal-wrap` changelog
+# `appsignal-run` changelog
 
 ## 0.2.1
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,8 +91,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "appsignal-wrap"
-version = "0.2.0"
+name = "appsignal-run"
+version = "0.2.1"
 dependencies = [
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "appsignal-wrap"
+name = "appsignal-run"
 version = "0.2.1"
 edition = "2021"
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# `appsignal-wrap`: monitor any process with AppSignal
+# `appsignal-run`: monitor any process with AppSignal
 
-`appsignal-wrap` is a tool that allows you to monitor any process with AppSignal. You can use it to:
+`appsignal-run` is a tool that allows you to monitor any process with AppSignal. You can use it to:
 
 - Send the process' standard output and standard error as logs to AppSignal, to be able to troubleshoot issues.
 - Send a start cron check-in to AppSignal when the process starts, and a finish cron check-in if it finishes successfully, to be able to track whether it runs successfully and on schedule.
@@ -8,27 +8,27 @@
 
 ## Installation
 
-The easiest way to get `appsignal-wrap` in your machine is to run our installation one-liner:
+The easiest way to get `appsignal-run` in your machine is to run our installation one-liner:
 
 ```sh
-curl -sSL https://github.com/appsignal/appsignal-wrap/releases/latest/download/install.sh | sh
+curl -sSL https://github.com/appsignal/appsignal-run/releases/latest/download/install.sh | sh
 ```
 
 You'll need to run it with super-user privileges -- if you're not running this as root, prefix it with `sudo`.
 
-`appsignal-wrap` is only supported for Linux and macOS, in the x86_64 (Intel) and arm64 (Apple Silicon) architectures. Linux distributions based on musl, such as Alpine, are also supported.
+`appsignal-run` is only supported for Linux and macOS, in the x86_64 (Intel) and arm64 (Apple Silicon) architectures. Linux distributions based on musl, such as Alpine, are also supported.
 
-Not a fan of `curl | sh` one-liners? Download the binary for your operating system and architecture [from our latest release](https://github.com/appsignal/appsignal-wrap/releases/latest/).
+Not a fan of `curl | sh` one-liners? Download the binary for your operating system and architecture [from our latest release](https://github.com/appsignal/appsignal-run/releases/latest/).
 
 ## Usage
 
-See `appsignal-wrap --help` for detailed information on all configuration options.
+See `appsignal-run --help` for detailed information on all configuration options.
 
 ```
-appsignal-wrap NAME [OPTIONS] -- COMMAND
+appsignal-run NAME [OPTIONS] -- COMMAND
 ```
 
-To use `appsignal-wrap`, you must provide an app-level API key. You can find the app-level API key in the [push and deploy settings](https://appsignal.com/redirect-to/app?to=api_keys) for your application.
+To use `appsignal-run`, you must provide an app-level API key. You can find the app-level API key in the [push and deploy settings](https://appsignal.com/redirect-to/app?to=api_keys) for your application.
 
 To provide the app-level API key, set it as the value for the `APPSIGNAL_APP_PUSH_API_KEY` environment variable, or pass it as the value for the `--api-key` command-line option.
 
@@ -38,25 +38,25 @@ Finally, you must provide a command to execute as the last argument, preceded by
 
 ### Send standard output and error as logs to AppSignal
 
-By default, `appsignal-wrap` will send the standard output and standard error of the command it executes as logs to AppSignal:
+By default, `appsignal-run` will send the standard output and standard error of the command it executes as logs to AppSignal:
 
 ```sh
-appsignal-wrap sync_customers -- python ./sync_customers.py
+appsignal-run sync_customers -- python ./sync_customers.py
 ```
 
-The above command will execute `python ./sync_customers.py` with the AppSignal wrapper, sending its standard output and error as logs to AppSignal.
+The above command will execute `python ./sync_customers.py` with the AppSignal runner, sending its standard output and error as logs to AppSignal.
 
 You can disable sending logs entirely by using the `--no-log` command-line option, and you can use `--no-stdout` and `--no-stderr` to control whether standard output and error are used to send logs to AppSignal.
 
 ### Report failure exit codes as errors to AppSignal
 
-By default, `appsignal-wrap` will report an error to AppSignal if the command it executes exits with a failure exit code, or if the command fails to be executed:
+By default, `appsignal-run` will report an error to AppSignal if the command it executes exits with a failure exit code, or if the command fails to be executed:
 
 ```sh
-appsignal-wrap sync_customers -- python ./sync_customers.py
+appsignal-run sync_customers -- python ./sync_customers.py
 ```
 
-The above command will attempt to execute `python ./sync_customers.py` with the AppSignal wrapper, and it will report an error to AppSignal if it fails to execute the command, or if the command ends with a failure exit code.
+The above command will attempt to execute `python ./sync_customers.py` with the AppSignal runner, and it will report an error to AppSignal if it fails to execute the command, or if the command ends with a failure exit code.
 
 You can disable sending errors entirely by using the `--no-error` command-line option.
 
@@ -65,7 +65,7 @@ You can disable sending errors entirely by using the `--no-error` command-line o
 Use the `--heartbeat` flag to send heartbeat check-ins continuously to AppSignal, for as long as the process is running. This allows you to track that certain processes are always up:
 
 ```sh
-appsignal-wrap worker --heartbeat -- bundle exec ruby ./worker.rb
+appsignal-run worker --heartbeat -- bundle exec ruby ./worker.rb
 ```
 
 The above command will execute `bundle exec ruby ./worker.rb`, and send heartbeat check-ins to AppSignal with the `worker` check-in identifier continuously, for as long as the process is running.
@@ -77,7 +77,7 @@ It will also send logs and report errors, as described in previous sections. To 
 Use the `--cron` flag to send a start cron check-in to AppSignal when the process starts, and a finish cron check-in to AppSignal if it finishes successfully. This allows you to track that certain processes are executed on schedule:
 
 ```sh
-appsignal-wrap sync_customers --cron -- python ./sync_customers.py
+appsignal-run sync_customers --cron -- python ./sync_customers.py
 ```
 
 The above command will execute `python ./sync_customers.py`, send a start cron check-in to AppSignal with the `sync_customers` check-in identifier if it starts successfully, and send a finish cron check-in to AppSignal if it finishes with a success exit code.
@@ -90,10 +90,10 @@ It will also send logs and report errors, as described in previous sections. To 
 
 You can use the `--heartbeat` command-line option to send heartbeat check-ins (named `database` in this example) to AppSignal periodically, for as long as the database process is running. This allows you to set up alerts that will notify you if the database is no longer running.
 
-In this example, we'll start `mysqld`, the MySQL server process, using `appsignal-wrap`:
+In this example, we'll start `mysqld`, the MySQL server process, using `appsignal-run`:
 
 ```sh
-appsignal-wrap database --heartbeat -- mysqld
+appsignal-run database --heartbeat -- mysqld
 ```
 
 This invocation can then be added to the `mysql.service` service definition:
@@ -102,13 +102,13 @@ This invocation can then be added to the `mysql.service` service definition:
 # /usr/lib/systemd/system/mysql.service
 
 [Service]
-# Modify the existing ExecStart line to add `appsignal-wrap`
-ExecStart=/usr/local/bin/appsignal-wrap database --heartbeat -- /usr/sbin/mysqld
+# Modify the existing ExecStart line to add `appsignal-run`
+ExecStart=/usr/local/bin/appsignal-run database --heartbeat -- /usr/sbin/mysqld
 # Add an environment variable containing the AppSignal app-level push API key
 Environment=APPSIGNAL_APP_PUSH_API_KEY=...
 ```
 
-In addition to sending heartbeat check-ins, by default `appsignal-wrap` will also: 
+In addition to sending heartbeat check-ins, by default `appsignal-run` will also: 
 
 - Send your database process' standard output and standard error as logs to AppSignal, under the `database` group
 - Report failure exit codes as errors to AppSignal, grouped under the `database` action
@@ -119,10 +119,10 @@ You can use the `--no-log` and `--no-error` command-line option to disable this 
 
 You can use the `--cron` command-line option to send cron check-ins (named `backup` in this example) to notify AppSignal when your cron job starts, and when it finishes, if and only if it finishes successfully.
 
-In this example, we'll run `/usr/local/bin/backup.sh`, our custom backup shell script, using `appsignal-wrap`:
+In this example, we'll run `/usr/local/bin/backup.sh`, our custom backup shell script, using `appsignal-run`:
 
 ```sh
-appsignal-wrap backup --cron -- bash /usr/local/bin/backup.sh
+appsignal-run backup --cron -- bash /usr/local/bin/backup.sh
 ```
 
 This invocation can then be added to the `/etc/crontab` file:
@@ -132,10 +132,10 @@ This invocation can then be added to the `/etc/crontab` file:
 
 APPSIGNAL_APP_PUSH_API_KEY=...
 
-0 2 * * * appsignal-wrap backup --cron -- bash /usr/local/bin/backup.sh
+0 2 * * * appsignal-run backup --cron -- bash /usr/local/bin/backup.sh
 ```
 
-In addition to sending cron check-ins, by default `appsignal-wrap` will also: 
+In addition to sending cron check-ins, by default `appsignal-run` will also: 
 
 - Send your database process' standard output and standard error as logs to AppSignal, under the `backup` group
 - Report failure exit codes as errors to AppSignal, grouped under the `backup` action

--- a/install.sh
+++ b/install.sh
@@ -3,12 +3,12 @@
 set -eu
 
 if ! command -v curl >/dev/null; then
-  echo "Error: \`curl\` is required to download the \`appsignal-wrap\` binary"
+  echo "Error: \`curl\` is required to download the \`appsignal-run\` binary"
   exit 1
 fi
 
 if ! command -v tar >/dev/null; then
-  echo "Error: \`tar\` is required to extract the \`appsignal-wrap\` binary"
+  echo "Error: \`tar\` is required to extract the \`appsignal-run\` binary"
   exit 1
 fi
 
@@ -16,8 +16,8 @@ fi
 # see `script/write_version`.
 LAST_RELEASE="0.2.1"
 
-VERSION="${APPSIGNAL_WRAP_VERSION:-"$LAST_RELEASE"}"
-INSTALL_FOLDER="${APPSIGNAL_WRAP_INSTALL_FOLDER:-"/usr/local/bin"}"
+VERSION="${APPSIGNAL_RUN_VERSION:-"$LAST_RELEASE"}"
+INSTALL_FOLDER="${APPSIGNAL_RUN_INSTALL_FOLDER:-"/usr/local/bin"}"
 
 # Expected values are "linux" or "darwin".
 OS="$(uname -s | tr '[:upper:]' '[:lower:]')"
@@ -84,15 +84,15 @@ else
 fi
 
 if [ "$VERSION" = "latest" ]; then
-  URL="https://github.com/appsignal/appsignal-wrap/releases/latest/download/$TRIPLE.tar.gz"
+  URL="https://github.com/appsignal/appsignal-run/releases/latest/download/$TRIPLE.tar.gz"
   VERSION_FRIENDLY="latest version"
 else
-  URL="https://github.com/appsignal/appsignal-wrap/releases/download/v$VERSION/$TRIPLE.tar.gz"
+  URL="https://github.com/appsignal/appsignal-run/releases/download/v$VERSION/$TRIPLE.tar.gz"
   VERSION_FRIENDLY="version $VERSION"
 fi
 
-echo "Downloading $VERSION_FRIENDLY of the \`appsignal-wrap\` binary for $TRIPLE_FRIENDLY..."
+echo "Downloading $VERSION_FRIENDLY of the \`appsignal-run\` binary for $TRIPLE_FRIENDLY..."
 
 curl --progress-bar -SL "$URL" | tar -C "$INSTALL_FOLDER" -xz
 
-echo "Done! Installed \`appsignal-wrap\` binary at \`$INSTALL_FOLDER/appsignal-wrap\`."
+echo "Done! Installed \`appsignal-run\` binary at \`$INSTALL_FOLDER/appsignal-run\`."

--- a/mono.yml
+++ b/mono.yml
@@ -1,6 +1,6 @@
 ---
 language: "custom"
-repo: "https://github.com/appsignal/appsignal-wrap"
+repo: "https://github.com/appsignal/appsignal-run"
 build:
   command: "echo 'Can only build from GitHub Actions'"
 publish:

--- a/script/build_artifact
+++ b/script/build_artifact
@@ -11,7 +11,7 @@ echo "Building for \`$TARGET\`..."
 echo
 
 cross build --release --target $TARGET
-tar -czvf release/$TARGET.tar.gz -C target/$TARGET/release appsignal-wrap
+tar -czvf release/$TARGET.tar.gz -C target/$TARGET/release appsignal-run
 
 echo "Done! Built release at \`release/$TARGET.tar.gz\`."
 echo


### PR DESCRIPTION
Also refer to it as a "runner" rather than a "wrapper" whenever possible.

See documentation matching the new name: https://github.com/appsignal/appsignal-docs/pull/2281

---

@tombruijn I'll need you to rename the repository, as I do not have permissions to do so.